### PR TITLE
Better error handling on Maps status code.

### DIFF
--- a/server/discord/commands/default.js
+++ b/server/discord/commands/default.js
@@ -55,6 +55,7 @@ module.exports = async function defaultCommand(message, args = []) {
       }
       const { data: { status, predictions } } = autoResp;
       if (status !== 'OK') {
+        Logger.error(new Error(`${status}: ${autoResp.data.error_message}`));
         await newMsg.edit(`😿 Hubo un error: No encontré el lugar \`${place}\`. Intenta con otra dirección.`);
         return;
       }
@@ -68,6 +69,7 @@ module.exports = async function defaultCommand(message, args = []) {
       }
       const { status: stats, results: [address] } = geoResp.data;
       if (stats !== 'OK') {
+        Logger.error(new Error(`${stats}: ${geoResp.data.error_message}`));
         await newMsg.edit(`😿 Hubo un error: No encontré el lugar \`${place}\`. Intenta con otra dirección.`);
         return;
       }


### PR DESCRIPTION
It returns HTTP 200 on errors.
Now we use the status code to handle errors.

based on:
```javascript
  data: {
    error_message: 'You must enable Billing on the Google Cloud Project at https://console.cloud.google.com/project/_/billing/enable Learn more at https://developers.google.com/maps/gmp-get-started',
    predictions: [],
    status: 'REQUEST_DENIED'
  }
```